### PR TITLE
Покращено переклад у vscode.git.xlf

### DIFF
--- a/vscode-extensions/uk/vscode.git.xlf
+++ b/vscode-extensions/uk/vscode.git.xlf
@@ -1807,7 +1807,7 @@ Please make sure there is no space between the right bracket and left parenthesi
       </trans-unit>
       <trans-unit id="config.smartCommitChanges.tracked">
         <source xml:lang="en">Automatically stage tracked changes only.</source>
-        <target>Автоматично  лише відстежені зміни.</target>
+        <target>Автоматично підготувати лише відстежені зміни.</target>
       </trans-unit>
       <trans-unit id="submenu.branch">
         <source xml:lang="en">Branch</source>

--- a/vscode-extensions/uk/vscode.git.xlf
+++ b/vscode-extensions/uk/vscode.git.xlf
@@ -2874,7 +2874,7 @@ Please make sure there is no space between the right bracket and left parenthesi
       </trans-unit>
       <trans-unit id="command.stageSelectedRanges">
         <source xml:lang="en">Stage Selected Ranges</source>
-        <target>Підготувати вибрані ділянки</target>
+        <target>Підготувати вибрані ділянки змін</target>
       </trans-unit>
       <trans-unit id="command.stageSelection">
         <source xml:lang="en">Stage Selection</source>

--- a/vscode-extensions/uk/vscode.git.xlf
+++ b/vscode-extensions/uk/vscode.git.xlf
@@ -958,7 +958,7 @@ Do not translate "Branch" as it is a git term</note>
       </trans-unit>
       <trans-unit id="++CODE++b5ff1947b664c6719dfbb25602ff832dd7fcfc5068944fa750a36fad11a9f7e6">
         <source xml:lang="en">Staged Changes</source>
-        <target>Сценічні зміни</target>
+        <target>Підготовлені зміни</target>
       </trans-unit>
       <trans-unit id="++CODE++1b0a609aede05f4f39c423b8a4b57d004741211ef76980e4a37179df32d731a5">
         <source xml:lang="en">Stash &amp; Checkout</source>
@@ -1807,7 +1807,7 @@ Please make sure there is no space between the right bracket and left parenthesi
       </trans-unit>
       <trans-unit id="config.smartCommitChanges.tracked">
         <source xml:lang="en">Automatically stage tracked changes only.</source>
-        <target>Автоматично стадіювати лише відстежені зміни.</target>
+        <target>Автоматично  лише відстежені зміни.</target>
       </trans-unit>
       <trans-unit id="submenu.branch">
         <source xml:lang="en">Branch</source>
@@ -2846,59 +2846,59 @@ Please make sure there is no space between the right bracket and left parenthesi
       </trans-unit>
       <trans-unit id="command.stageAll">
         <source xml:lang="en">Stage All Changes</source>
-        <target>Стадія всіх змін</target>
+        <target>Підготувати всі зміни</target>
       </trans-unit>
       <trans-unit id="command.stageAllMerge">
         <source xml:lang="en">Stage All Merge Changes</source>
-        <target>Стадія всіх змін злиття</target>
+        <target>Підготувати всі зміни злиття</target>
       </trans-unit>
       <trans-unit id="command.stageAllTracked">
         <source xml:lang="en">Stage All Tracked Changes</source>
-        <target>Стадія всіх відстежених змін</target>
+        <target>Підготувати всі відстежені зміни</target>
       </trans-unit>
       <trans-unit id="command.stageAllUntracked">
         <source xml:lang="en">Stage All Untracked Changes</source>
-        <target>Стадіювати всі непідконтрольні зміни</target>
+        <target>Підготувати всі невідстежувані зміни</target>
       </trans-unit>
       <trans-unit id="command.stageBlock">
         <source xml:lang="en">Stage Block</source>
-        <target>Блок Сцени</target>
+        <target>Підготувати блок</target>
       </trans-unit>
       <trans-unit id="command.stageChange">
         <source xml:lang="en">Stage Change</source>
-        <target>Зміна етапу</target>
+        <target>Підготувати зміну</target>
       </trans-unit>
       <trans-unit id="command.stage">
         <source xml:lang="en">Stage Changes</source>
-        <target>Зміни стадії</target>
+        <target>Підготувати зміни</target>
       </trans-unit>
       <trans-unit id="command.stageSelectedRanges">
         <source xml:lang="en">Stage Selected Ranges</source>
-        <target>Етап вибраних діапазонів</target>
+        <target>Підготувати вибрані ділянки</target>
       </trans-unit>
       <trans-unit id="command.stageSelection">
         <source xml:lang="en">Stage Selection</source>
-        <target>Вибір етапу</target>
+        <target>Підготувати вибрані зміни</target>
       </trans-unit>
       <trans-unit id="submenu.stash">
         <source xml:lang="en">Stash</source>
-        <target>Сховище</target>
+        <target>Сховати зміни</target>
       </trans-unit>
       <trans-unit id="command.stash">
         <source xml:lang="en">Stash</source>
-        <target>Сховище</target>
+        <target>Сховати зміни</target>
       </trans-unit>
       <trans-unit id="command.stashIncludeUntracked">
         <source xml:lang="en">Stash (Include Untracked)</source>
-        <target>Сховати (Включити непідраховані)</target>
+        <target>Сховати (включно з невідстежуваними)</target>
       </trans-unit>
       <trans-unit id="command.stashStaged">
         <source xml:lang="en">Stash Staged</source>
-        <target>Сховати стадію</target>
+        <target>Сховати підготовлені зміни</target>
       </trans-unit>
       <trans-unit id="config.autoStash">
         <source xml:lang="en">Stash any changes before pulling and restore them after successful pull.</source>
-        <target>Збережіть будь-які зміни перед отриманням і відновіть їх після успішного отримання.</target>
+        <target>Сховати всі зміни перед отриманням і відновити їх після успішного отримання.</target>
       </trans-unit>
       <trans-unit id="config.suggestSmartCommit">
         <source xml:lang="en">Suggests to enable smart commit (commit all changes when there are no staged changes).</source>


### PR DESCRIPTION
Переклав кілька рядків в vscode.git.xlf файлі. Просто користувався локалізацією і побачив кілька фраз які не мали сенсу. До цього я користувався англійською і зрозумів що присутні українські відповідники не були дуже правильними. Дякую.